### PR TITLE
fix: theme parser middleware

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -41,7 +41,8 @@ export const handle: Handle = async ({ event, resolve }) => {
 		return await resolve(event);
 	});
 
-	return await ThemeParser.parse({ response, cookies: event.cookies });
+	const themeParsedResponse = await ThemeParser.parse({ response, cookies: event.cookies });
+	return themeParsedResponse;
 };
 
 export const handleFetch: HandleFetch = async ({ request, fetch, event }) => {

--- a/src/lib/theme-parser.ts
+++ b/src/lib/theme-parser.ts
@@ -25,6 +25,9 @@ export class ThemeParser {
 
 		const { headers: responseHeaders, ...responseData } = response;
 		const headers = new Headers(responseHeaders);
+		const newBodyLength = new Blob([body]).size;
+
+		headers.set("content-length", newBodyLength.toString());
 
 		return new Response(body, {
 			...responseData,


### PR DESCRIPTION
Add content-length header again, but using `Blob` to get the body bytes size.