### PR TITLE
fix: SEO metatags

### DIFF
--- a/src/components/meta/description.svelte
+++ b/src/components/meta/description.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
 	type Props = {
-		description: string;
+		description?: string;
 		adminRoute?: boolean;
 	};
 
-	const { description, adminRoute = false }: Props = $props();
+	const {
+		description = "Programador; Desenvolvedor, Analista ou Engenheiro de software; Cientista da Computação. Alguma coisa do gênero.",
+		adminRoute = false,
+	}: Props = $props();
 </script>
 
 {#if !adminRoute}

--- a/src/components/meta/index.ts
+++ b/src/components/meta/index.ts
@@ -5,7 +5,7 @@ import Root from "./root.svelte";
 import Title from "./title.svelte";
 
 type ResolveTitleArgs = {
-	title: string;
+	title?: string;
 	adminRoute?: boolean;
 };
 

--- a/src/components/meta/index.ts
+++ b/src/components/meta/index.ts
@@ -14,6 +14,15 @@ export function resolveTitle({ title, adminRoute = false }: ResolveTitleArgs) {
 	return title ? `${formerPart} :: ${title}` : formerPart;
 }
 
+export function resolveCanonicalUrl(base: string, location?: string) {
+	if (!location) return base;
+
+	if (!location.startsWith("/")) location = "/" + location;
+	if (base.endsWith("/")) base = base.substring(0, base.length - 1);
+
+	return base + location;
+}
+
 export default {
 	Root,
 	Title,

--- a/src/components/meta/root.svelte
+++ b/src/components/meta/root.svelte
@@ -1,13 +1,31 @@
 <script lang="ts">
+	import { env } from "$env/dynamic/public";
 	import type { Snippet } from "svelte";
+	import { resolveCanonicalUrl } from ".";
 
 	type Props = {
-		children: Snippet;
+		children?: Snippet;
+		location?: string;
+		isAdmin?: boolean;
 	};
 
-	const { children }: Props = $props();
+	let { children, location, isAdmin = false }: Props = $props();
+	const canonicalUrl = resolveCanonicalUrl(env.PUBLIC_APP_URL, location);
 </script>
 
 <svelte:head>
-	{@render children()}
+	<!-- base metatags -->
+	<meta property="og:locale" content="pt_BR" />
+	<meta property="og:type" content="website" />
+	<meta property="theme-color" content="#FFC700" />
+
+	<meta property="og:site_name" content={env.PUBLIC_APP_NAME} />
+	<meta name="application-name" content={env.PUBLIC_APP_NAME} />
+
+	{#if !isAdmin}
+		<link rel="canonical" href={canonicalUrl} />
+		<meta name="og:url" content={canonicalUrl} />
+	{/if}
+
+	{@render children?.()}
 </svelte:head>

--- a/src/components/meta/title.svelte
+++ b/src/components/meta/title.svelte
@@ -2,7 +2,7 @@
 	import { resolveTitle } from ".";
 
 	type Props = {
-		title: string;
+		title?: string;
 		adminRoute?: boolean;
 	};
 

--- a/src/routes/(public)/+layout.svelte
+++ b/src/routes/(public)/+layout.svelte
@@ -4,7 +4,6 @@
 	import MobileHeader from "$crate/ui/mobile-header.svelte";
 	import { afterNavigate, beforeNavigate } from "$app/navigation";
 	import type { Snippet } from "svelte";
-	import { env } from "$env/dynamic/public";
 
 	let loading = $state(false);
 
@@ -13,26 +12,6 @@
 
 	const { children }: { children: Snippet } = $props();
 </script>
-
-<svelte:head>
-	<!-- base metatags -->
-	<meta property="og:locale" content="pt_BR" />
-	<meta property="og:type" content="website" />
-	<meta property="theme-color" content="#FFC700" />
-
-	<meta property="og:site_name" content={env.PUBLIC_APP_NAME} />
-	<meta name="application-name" content={env.PUBLIC_APP_NAME} />
-
-	<link rel="canonical" href={env.PUBLIC_APP_URL} />
-	<meta name="og:url" content={env.PUBLIC_APP_URL} />
-
-	<!-- overridable -->
-	<title>{env.PUBLIC_APP_NAME}</title>
-	<meta
-		name="description"
-		content="Programador; Desenvolvedor, Analista ou Engenheiro de software; Cientista da Computação. Alguma coisa do gênero."
-	/>
-</svelte:head>
 
 <div class="flex-1 flex flex-col">
 	{#if loading}

--- a/src/routes/(public)/+page.svelte
+++ b/src/routes/(public)/+page.svelte
@@ -1,6 +1,12 @@
 <script>
 	import ArrowRight from "phosphor-svelte/lib/ArrowRight";
+	import Meta from "$crate/components/meta";
 </script>
+
+<Meta.Root>
+	<Meta.Title />
+	<Meta.Description />
+</Meta.Root>
 
 <main
 	class="flex-1 w-[calc(100%_-_24px)] max-w-screen-main mx-auto flex flex-col items-center justify-center"

--- a/src/routes/(public)/blog/+page.svelte
+++ b/src/routes/(public)/blog/+page.svelte
@@ -86,7 +86,7 @@
 	}
 </script>
 
-<Meta.Root>
+<Meta.Root location="/blog">
 	<Meta.Title title="Blog" />
 	<Meta.Description
 		description="Artigos sobre o que eu venho aprontando ou sobre coisas que, aparentemente, todo mundo sabia mas eu acabei de descobrir!"

--- a/src/routes/(public)/blog/[slug]/+page.svelte
+++ b/src/routes/(public)/blog/[slug]/+page.svelte
@@ -18,10 +18,10 @@
 	}
 </script>
 
-<meta.Root>
+<meta.Root location="/blog/{data.success && data.data ? data.data.slug : ''}">
 	<meta.Title title={data.success && data.data ? data.data.title : "Post não encontrado"} />
+	<meta.Description description={data.success ? data.data?.description : undefined} />
 	{#if data.success && data.data}
-		<meta.Description description={data.data.description} />
 		<meta.Image url={data.data.topstory} />
 		<meta.Card url={data.data.topstory} />
 	{/if}

--- a/src/routes/(public)/projetos/+page.svelte
+++ b/src/routes/(public)/projetos/+page.svelte
@@ -100,7 +100,7 @@
 	}
 </script>
 
-<meta.Root>
+<meta.Root location="/projetos">
 	<meta.Title title="Projetos" />
 	<meta.Description
 		description="Projetos nos quais eu venho trabalhando, já trabalhei, e/ou dou manutenção!"

--- a/src/routes/(public)/sobre/+page.svelte
+++ b/src/routes/(public)/sobre/+page.svelte
@@ -10,8 +10,9 @@
 	const yearsStudying = getYearsFromNow(startedStudyingAt);
 </script>
 
-<meta.Root>
+<meta.Root location="/sobre">
 	<meta.Title title="Sobre mim" />
+	<meta.Description />
 </meta.Root>
 
 <main


### PR DESCRIPTION
SvelteKit is unable to deduplicate meta tags if they are not declared within the same `<svelte:head>` tag. Having some default tags in layouts would not work, not even within `meta` custom component.

The only solution is to require every meta tag to be present on every page, even if with undefined properties so that the defaults are correctly rendered.